### PR TITLE
Split shared chart resources into a separate chunk

### DIFF
--- a/dash_mantine_components/__init__.py
+++ b/dash_mantine_components/__init__.py
@@ -11,8 +11,8 @@ from . import styles
 # noinspection PyUnresolvedReferences
 from ._imports_ import *
 from ._imports_ import __all__
-from .theme import DEFAULT_THEME
 from .figure_templates import add_figure_templates
+from .theme import DEFAULT_THEME
 
 if not hasattr(_dash, "__plotly_dash") and not hasattr(_dash, "development"):
     print(
@@ -35,75 +35,63 @@ _current_path = _os.path.dirname(_os.path.abspath(__file__))
 
 _this_module = _sys.modules[__name__]
 
+# Add async components here.
+async_resources = [
+    "AreaChart",
+    "BarChart",
+    "LineChart",
+    "BubbleChart",
+    "DonutChart",
+    "PieChart",
+    "RadarChart",
+    "ScatterChart",
+    "CompositeChart",
+    "Sparkline",
+    "CodeHighlight",
+    "CodeHighlightTabs",
+    "InlineCodeHighlight",
+]
+async_chunks = [f"async-{async_resource}" for async_resource in async_resources]
 
-async_resources = ["AreaChart", "BarChart", "LineChart", "BubbleChart", "DonutChart", "PieChart",
-                   "RadarChart", "ScatterChart", "CompositeChart", "Sparkline",
-                   "CodeHighlight", "CodeHighlightTabs", "InlineCodeHighlight"]
+# Add shared chunks here.
+shared_chunks = [
+    f"{__name__}-shared",
+    f"{__name__}-charts-shared",
+]
 
+# Collect all chunks (main, async, shared).
+chunks = [__name__] + async_chunks + shared_chunks
 
+# Add all chunks to the js_dist list.
 _js_dist = []
-
-
 _js_dist.extend(
     [
         {
-            "relative_package_path": f"async-{async_resource}.js",
-            "external_url": (
-                f"https://unpkg.com/{package_name}@{__version__}/{__name__}/async-{async_resource}.js"
-            ),
+            "relative_package_path": f"{chunk}.js",
+            "external_url": f"https://unpkg.com/{package_name}@{__version__}/{__name__}/{chunk}.js",
             "namespace": package_name,
-            "async": True,
+            "async": chunk != __name__,  # don't make the main bundle async
         }
-        for async_resource in async_resources
+        for chunk in chunks
     ]
 )
-
-# TODO: Figure out if unpkg link works
 _js_dist.extend(
     [
         {
-            "relative_package_path": f"async-{async_resource}.js.map",
-            "external_url": f"https://unpkg.com/{package_name}@{__version__}/{__name__}/async-{async_resource}.js.map",
+            "relative_package_path": f"{chunk}.js.map",
+            "external_url": f"https://unpkg.com/{package_name}@{__version__}/{__name__}/{chunk}.js.map",
             "namespace": package_name,
             "dynamic": True,
         }
-        for async_resource in async_resources
+        for chunk in chunks
     ]
 )
 
-_js_dist.extend(
-    [
-        {
-            "relative_package_path": "dash_mantine_components.js",
-            "external_url": f"https://unpkg.com/{package_name}@{__version__}/{__name__}/{__name__}.js",
-            "namespace": package_name,
-        },
-        {
-            "relative_package_path": "dash_mantine_components.js.map",
-            "external_url": f"https://unpkg.com/{package_name}@{__version__}/{__name__}/{__name__}.js.map",
-            "namespace": package_name,
-            "dynamic": True,
-        },
-        {
-            "relative_package_path": "dash_mantine_components-shared.js",
-            "external_url": f"https://unpkg.com/{package_name}@{__version__}/{__name__}/{__name__}-shared.js",
-            "namespace": package_name,
-        },
-        {
-            "relative_package_path": "dash_mantine_components-shared.js.map",
-            "external_url": f"https://unpkg.com/{package_name}@{__version__}/{__name__}/{__name__}-shared.js.map",
-            "namespace": package_name,
-            "dynamic": True,
-        },
-    ]
-)
-
+# Similarly, collect CSS.
 _css_dist = []
-
 
 for _component in __all__:
     setattr(locals()[_component], "_js_dist", _js_dist)
     setattr(locals()[_component], "_css_dist", _css_dist)
-
 
 __all__ += [DEFAULT_THEME, styles, add_figure_templates]

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -112,7 +112,7 @@ module.exports = function (env, argv) {
                         chunks: "all",
                         minSize: 0,
                         minChunks: 2,
-                        name: "dash_mantine_components-charts_shared",
+                        name: "dash_mantine_components-charts-shared",
                         priority: 20,
                     },
                     shared: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,34 +1,34 @@
-const path = require('path');
-const packagejson = require('./package.json');
-const WebpackDashDynamicImport = require('@plotly/webpack-dash-dynamic-import');
+const path = require("path");
+const packagejson = require("./package.json");
+const WebpackDashDynamicImport = require("@plotly/webpack-dash-dynamic-import");
 
-const dashLibraryName = packagejson.name.replace(/-/g, '_');
+const dashLibraryName = packagejson.name.replace(/-/g, "_");
 
 module.exports = function (env, argv) {
-    const mode = (argv && argv.mode) || 'production';
-    const entry = [path.join(__dirname, 'src/ts/index.ts')];
+    const mode = (argv && argv.mode) || "production";
+    const entry = [path.join(__dirname, "src/ts/index.ts")];
     const output = {
         path: path.join(__dirname, dashLibraryName),
-        chunkFilename: '[name].js',
+        chunkFilename: "[name].js",
         filename: `${dashLibraryName}.js`,
         library: dashLibraryName,
-        libraryTarget: 'umd',
-    }
+        libraryTarget: "umd",
+    };
 
     const externals = {
         react: {
-            commonjs: 'react',
-            commonjs2: 'react',
-            amd: 'react',
-            umd: 'react',
-            root: 'React',
+            commonjs: "react",
+            commonjs2: "react",
+            amd: "react",
+            umd: "react",
+            root: "React",
         },
-        'react-dom': {
-            commonjs: 'react-dom',
-            commonjs2: 'react-dom',
-            amd: 'react-dom',
-            umd: 'react-dom',
-            root: 'ReactDOM',
+        "react-dom": {
+            commonjs: "react-dom",
+            commonjs2: "react-dom",
+            amd: "react-dom",
+            umd: "react-dom",
+            root: "ReactDOM",
         },
     };
 
@@ -36,23 +36,23 @@ module.exports = function (env, argv) {
         output,
         mode,
         entry,
-        target: 'web',
+        target: "web",
         externals,
         resolve: {
-            extensions: ['.ts', '.tsx', '.js', '.jsx', '.json'],
+            extensions: [".ts", ".tsx", ".js", ".jsx", ".json"],
         },
         module: {
             rules: [
                 {
                     test: /\.tsx?$/,
-                    use: 'ts-loader',
+                    use: "ts-loader",
                     exclude: /node_modules/,
                 },
                 {
                     test: /\.css$/,
                     use: [
                         {
-                            loader: 'style-loader',
+                            loader: "style-loader",
                             options: {
                                 insert: function insertAtTop(element) {
                                     var parent = document.querySelector("head");
@@ -60,50 +60,70 @@ module.exports = function (env, argv) {
                                         window._lastElementInsertedByStyleLoader;
 
                                     if (!lastInsertedElement) {
-                                        parent.insertBefore(element, parent.firstChild);
-                                    } else if (lastInsertedElement.nextSibling) {
-                                        parent.insertBefore(element, lastInsertedElement.nextSibling);
+                                        parent.insertBefore(
+                                            element,
+                                            parent.firstChild
+                                        );
+                                    } else if (
+                                        lastInsertedElement.nextSibling
+                                    ) {
+                                        parent.insertBefore(
+                                            element,
+                                            lastInsertedElement.nextSibling
+                                        );
                                     } else {
                                         parent.appendChild(element);
                                     }
 
-                                    window._lastElementInsertedByStyleLoader = element;
+                                    window._lastElementInsertedByStyleLoader =
+                                        element;
                                 },
                             },
                         },
                         {
-                            loader: 'css-loader',
+                            loader: "css-loader",
                         },
                     ],
                 },
                 {
-                   test:  /\.(png|jpe?g|gif|svg)$/i,
-                   type: 'asset/inline'
-                }
-            ]
+                    test: /\.(png|jpe?g|gif|svg)$/i,
+                    type: "asset/inline",
+                },
+            ],
         },
         optimization: {
             splitChunks: {
-                name: '[name].js',
+                name: "[name].js",
                 cacheGroups: {
                     async: {
-                        chunks: 'async',
+                        chunks: "async",
                         minSize: 0,
                         name(module, chunks, cacheGroupKey) {
                             return `${cacheGroupKey}-${chunks[0].name}`;
-                        }
+                        },
                     },
-                    shared: {
-                        chunks: 'all',
+                    charts: {
+                        test(module, { chunkGraph }) {
+                            const chunks = chunkGraph.getModuleChunks(module);
+                            return Array.from(chunks).some((chunk) =>
+                                /(?:Chart|Sparkline)$/.test(chunk.name)
+                            );
+                        },
+                        chunks: "all",
                         minSize: 0,
                         minChunks: 2,
-                        name: 'dash_mantine_components-shared'
-                    }
-                }
-            }
+                        name: "dash_mantine_components-charts_shared",
+                        priority: 20,
+                    },
+                    shared: {
+                        chunks: "all",
+                        minSize: 0,
+                        minChunks: 2,
+                        name: "dash_mantine_components-shared",
+                    },
+                },
+            },
         },
-        plugins: [
-            new WebpackDashDynamicImport()
-        ]
-    }
-}
+        plugins: [new WebpackDashDynamicImport()],
+    };
+};


### PR DESCRIPTION
In the current implementation the (generic) shared chunk becomes large. This PR aims to do the split more efficiently by moving functionality shared across chart-related chunks (which share a lot since they are all rechart-based) into a separate (shared) chunk. As a result, the chunk including recharts (the +400 kB one) will only be loaded, if charts are used,

![image](https://github.com/user-attachments/assets/7442f60c-f81e-42b4-89ba-3ee4f5edd5f2)

Furthermore, the code highlight code ends up in a separate (big!) chunk. I think the design will yield an improved loading experience overall.

